### PR TITLE
Provision AWS VPC with Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,27 @@
+
+
+# Ignore Terraform state files
 *.tfstate
-*.tfstate.*
+*.tfstate.backup
+
+# Ignore the .terraform directory
 .terraform/
-*.tfvars
-*.backup
+
+# Ignore lock files
+*terraform.tf.lock.hcl
+
+# Ignore any generated files or directories
+*.tfvars.json
+*.tfplan
+
+# Exclude sensitive variable override files
+*.auto.tfvars
+
+# Exclude local override files
+override.tf
+
+# Exclude log files
+*.log
+
+# Ignore macOS metadata files
+.DS_Store

--- a/bootstrap/.terraform.lock.hcl
+++ b/bootstrap/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "5.5.0"
   hashes = [
     "h1:5JUwJKwvCdnZ7m7n5juvhZJyZ6SFCUyIqIi79211HsI=",
+    "h1:WOweXv4ZjePZwdxuzE2UmRWOPhhcQDNxGu2wOcpHFWY=",
     "zh:10fe0ef4191323c920c1844f27dbc88114547d5f78fad915c1769c908f40d916",
     "zh:565fc7c3a1f42474fa75f143cb8115e11b894ed7fd9973569b00bd429fb92b4e",
     "zh:5ba6132b1d442ed679ad8ea89fb5602aa0893e8dcd002a52ab3d76591aa18c8b",

--- a/deployed/production/.terraform.lock.hcl
+++ b/deployed/production/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.8.0"
+  hashes = [
+    "h1:LeGaxHyCnTpZdrhVCSJwDx91JcPWXlf4Rt4mnlF34Gs=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/deployed/production/main.tf
+++ b/deployed/production/main.tf
@@ -7,3 +7,7 @@ terraform {
     encrypt = true
   }
 }
+
+module "setup_module"{
+  source = "../../modules/hello-world"
+}

--- a/modules/hello-world/instance.tf
+++ b/modules/hello-world/instance.tf
@@ -1,0 +1,40 @@
+
+resource "aws_vpc" "issue-tracker-vpc"{
+    cidr_block = var.vpc_cidr
+    tags = {
+        Name = "VPC: issue-tracker-eu-west-2"
+    }
+}
+
+resource "aws_subnet" "aws_issue_tracker_public_subnets"{
+    count = length(var.cidr_public_subnets)
+    vpc_id = aws_vpc.issue-tracker-vpc.id
+    cidr_block = element(var.cidr_public_subnets,count.index)
+    availability_zone = element(var.availability_zones,count.index)
+
+    tags = {
+        Name = "Subnet-Public: Public subnet ${count.index+1}"
+    }
+}
+
+resource "aws_subnet" "aws_issue_tracker_private_web_subnets"{
+    count = length(var.cidr_private_web_subnets)
+    vpc_id = aws_vpc.issue-tracker-vpc.id
+    cidr_block = element(var.cidr_private_web_subnets,count.index)
+    availability_zone = element(var.availability_zones,count.index)
+
+    tags = {
+        Name = "Subnet-Private : Private web subnet ${count.index+1}"
+    }
+}
+
+resource "aws_subnet" "aws_issue_tracker_private_db_subnets"{
+    count = length(var.cidr_private_db_subnets)
+    vpc_id = aws_vpc.issue-tracker-vpc.id
+    cidr_block = element(var.cidr_private_db_subnets,count.index)
+    availability_zone = element(var.availability_zones,count.index)
+
+    tags = {
+        Name = "Subnet-Private : Private Database subnet ${count.index+1}"
+    }
+}

--- a/modules/hello-world/instance.tf
+++ b/modules/hello-world/instance.tf
@@ -1,5 +1,5 @@
 
-resource "aws_vpc" "issue-tracker-vpc"{
+resource "aws_vpc" "issue_tracker_vpc"{
     cidr_block = var.vpc_cidr
     tags = {
         Name = "VPC: issue-tracker-eu-west-2"
@@ -8,7 +8,7 @@ resource "aws_vpc" "issue-tracker-vpc"{
 
 resource "aws_subnet" "aws_issue_tracker_public_subnets"{
     count = length(var.cidr_public_subnets)
-    vpc_id = aws_vpc.issue-tracker-vpc.id
+    vpc_id = aws_vpc.issue_tracker_vpc.id
     cidr_block = element(var.cidr_public_subnets,count.index)
     availability_zone = element(var.availability_zones,count.index)
 
@@ -19,7 +19,7 @@ resource "aws_subnet" "aws_issue_tracker_public_subnets"{
 
 resource "aws_subnet" "aws_issue_tracker_private_web_subnets"{
     count = length(var.cidr_private_web_subnets)
-    vpc_id = aws_vpc.issue-tracker-vpc.id
+    vpc_id = aws_vpc.issue_tracker_vpc.id
     cidr_block = element(var.cidr_private_web_subnets,count.index)
     availability_zone = element(var.availability_zones,count.index)
 
@@ -30,11 +30,32 @@ resource "aws_subnet" "aws_issue_tracker_private_web_subnets"{
 
 resource "aws_subnet" "aws_issue_tracker_private_db_subnets"{
     count = length(var.cidr_private_db_subnets)
-    vpc_id = aws_vpc.issue-tracker-vpc.id
+    vpc_id = aws_vpc.issue_tracker_vpc.id
     cidr_block = element(var.cidr_private_db_subnets,count.index)
     availability_zone = element(var.availability_zones,count.index)
 
     tags = {
         Name = "Subnet-Private : Private Database subnet ${count.index+1}"
     }
+}
+
+resource "aws_internet_gateway" "issue_tracker_internet_gateway"{
+    
+    vpc_id = aws_vpc.issue_tracker_vpc.id
+
+    tags = {
+        Name = "Issue Tracker Gateway"
+    }
+}
+
+resource "aws_route_table" "issue_tracker_public_route_table"{
+    vpc_id = aws_vpc.issue_tracker_vpc.id
+    route{
+        cidr_block = "0.0.0.0/0"
+        gateway_id = aws_internet_gateway.issue_tracker_internet_gateway.id
+    }
+    tags = {
+        Name = "Route Table, Public, Issue Tracker"
+    }
+
 }

--- a/modules/hello-world/variables.tf
+++ b/modules/hello-world/variables.tf
@@ -1,0 +1,30 @@
+
+variable "vpc_cidr" {
+    type = string
+    description = "The CIDR block for the issue-tracker-vpc"
+    default  = "10.0.0.0/16"
+}
+
+variable "cidr_public_subnets"{
+    type = list(string)
+    description = "The CIDR blocks for the public subnets"
+    default  = ["10.0.0.0/24", "10.0.1.0/24"]
+}
+
+variable "cidr_private_web_subnets"{
+    type = list(string)
+    description = "The CIDR blocks for the public subnets"
+    default  = ["10.0.3.0/24", "10.0.4.0/24"]
+
+}
+variable "cidr_private_db_subnets"{
+    type = list(string)
+    description = "The CIDR blocks for the public subnets"
+    default  = ["10.0.5.0/24", "10.0.6.0/24"]
+}
+
+variable "availability_zones"{
+    type = list(string)
+    description = "AZs to be used in our VPC"
+    default  = ["eu-west-2a", "eu-west-2b"]
+}


### PR DESCRIPTION
This PR provisions an AWS VPC via Terraform in response to the issue "Provision a Virtual Private Cloud (VPC) using Terraform".

Changes include:

    VPC creation with variable CIDR block
    Public, private web, and private database subnets creation
    Internet gateway attached to VPC
    Public route table with a default route to the created Internet Gateway